### PR TITLE
fixing version comparison and evaluation logic in rule CVE-2021-25742

### DIFF
--- a/rules/CVE-2021-25742/raw.rego
+++ b/rules/CVE-2021-25742/raw.rego
@@ -6,7 +6,15 @@ deny[msga] {
 	image := deployment.spec.template.spec.containers[i].image
 	is_nginx_image(image)
 	is_tag_image(image)
-	is_vulnerable(image, deployment.metadata.namespace)
+
+	# Extracting version from image tag
+	tag_version_match := regex.find_all_string_submatch_n("[0-9]+\\.[0-9]+\\.[0-9]+", image, -1)[0][0]
+    image_version_str_arr := split(tag_version_match,".")
+	image_version_arr := [to_number(image_version_str_arr[0]),to_number(image_version_str_arr[1]),to_number(image_version_str_arr[2])]
+
+	# Check if vulnerable 
+	is_vulnerable(image_version_arr, deployment.metadata.namespace)
+
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	msga := {
 			"alertMessage": sprintf("You may be vulnerable to CVE-2021-25742. Deployment %v", [deployment.metadata.name]),
@@ -29,78 +37,32 @@ is_nginx_image(image) {
 	contains(image, "ingress-nginx")
 }
 
-is_vulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    startswith(tag, "v")
-    tag <= "v0.49"
-}
-	
-is_vulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    startswith(tag, "v")
-    tag  == "v1.0.0"
-}
-
-is_vulnerable(image, namespace) {
-	not contains(image, "@")
-	version := split(image, ":")
-	tag := version[count(version)-1]
-    startswith(tag, "v")
-	tag <= "v0.49"
-}
-
-is_vulnerable(image, namespace) {
-	not contains(image, "@")
-	version := split(image, ":")
-	tag := version[count(version)-1]
-    startswith(tag, "v")
-	tag  == "v1.0.0"
-}
-
-###### without 'v'
-	
-is_vulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    not startswith(tag, "v")
-    tag <= "0.49"
-}
-	
-is_vulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    not startswith(tag, "v")
-    tag  == "1.0.0"
-}
-
-is_vulnerable(image, namespace) {
-	not contains(image, "@")
-	version := split(image, ":")
-	tag := version[count(version)-1]
-    not startswith(tag, "v")
-	tag <= "0.49"
-}
-is_vulnerable(image, namespace) {
-	not contains(image, "@")
-	version := split(image, ":")
-	tag := version[count(version)-1]
-    not startswith(tag, "v")
-	tag  == "1.0.0"
-}
-
-is_vulnerable(image, namespace) {
+is_allow_snippet_annotation_on(namespace) {
     configmaps := [configmap | configmap = input[_]; configmap.kind == "ConfigMap"]
 	configmap_on_ingress_namespace := [configmap |  configmap= configmaps[_]; configmap.metadata.namespace == namespace]
 	config_maps_with_snippet := [configmap |  configmap= configmap_on_ingress_namespace[_];  configmap.data["allow-snippet-annotations"] == "false"]
 	count(config_maps_with_snippet) < 1
 }
 
+is_vulnerable(image_version, namespace) {
+	image_version[0] == 0
+	image_version[1] < 49
+	is_allow_snippet_annotation_on(namespace)
+}
+
+is_vulnerable(image_version, namespace) {
+	image_version[0] == 0
+	image_version[1] == 49
+	image_version[2] == 0
+	is_allow_snippet_annotation_on(namespace)
+}
+	
+is_vulnerable(image_version, namespace) {
+	image_version[0] == 1
+	image_version[1] == 0
+	image_version[2] == 0
+	is_allow_snippet_annotation_on(namespace)
+}
 
 is_tag_image(image) {
     reg := ":[\\w][\\w.-]{0,127}(\/)?"


### PR DESCRIPTION
= MUST BE REVIEWED B4 MERGE = 

1. In rule CVE-2021-25742 rule the version extraction and comprisons were badly implemented (string to string comparison). This was fixes with proper regexp extraction and string to number conversion
2. In my understanding (thus waiting for review by @leonidsandler ) both the version needs to be vulnerable and `allow-snippet-annotations` has to be `false` for this vulnerability to be exploitable. The previous implementation fired an alert on either case not both case. 